### PR TITLE
Rollback "call.sort" -> "call.reverse"

### DIFF
--- a/lib/calllist.js
+++ b/lib/calllist.js
@@ -205,7 +205,7 @@ const callLists = function () {
 
         if (Array.isArray(call)) {
             adapter.log.debug('Separating parallel calls for calllist handling');
-            call.sort((a,b) => (a.id > b.id) ? 1 : -1); // was call.reverse(); before
+            call.reverse();
             call.forEach(singleCall => {
                 this.addCall(singleCall); // process all calls of the array
                 // but don't update lastId if an earlier started call is still active
@@ -215,6 +215,7 @@ const callLists = function () {
 
                 if (!blocker && singleCall.id > systemData.native.callLists.lastId) {
                     systemData.native.callLists.lastId = singleCall.id;
+                    adapter.log.debug('Last.id updated to ' + singleCall.id);
                 }
             });
         } else {


### PR DESCRIPTION
zurück zu   call.reverse();    statt    call.sort((a,b) => (a.id > b.id) ? 1 : -1);
weil bei call.sort alphanumerisch sortiert wird, was zu Fehlern in der Sortierung führt, wenn sich die Anzahl der Ziffern in der call.id bei einem Abruf von der Fritzbox ändert (also z.B. beim 10. Anruf, beim 100, Anruf und beim 1000. Anruf nach der ersten Inbetriebnahme der Fritzbox, dürfte also in der Lebenszeit einer Fritzbox nur wenige Male vorkommen, falls nicht gerade ein Call Center darüber betrieben wird ;-)