### PR TITLE
Fix calllist handling for blocked calls

### DIFF
--- a/lib/calllist.js
+++ b/lib/calllist.js
@@ -183,7 +183,7 @@ const callLists = function () {
         call.id = ~~call.id;
 
         if (call.type > 3) {
-            adapter.log.debug('Ignoring call ID' + call.id + ' because call still active (call.type = ' + call.type + ')');
+            adapter.log.debug('Ignoring call ID' + call.id + ' because call still active or blocked (call.type = ' + call.type + ')');
         } else {
             adapter.log.debug('Processing call ID' + call.id + ' (call.type = ' + call.type + ')');
             call.sym = SYMS[call.type];
@@ -209,13 +209,12 @@ const callLists = function () {
             call.forEach(singleCall => {
                 this.addCall(singleCall); // process all calls of the array
                 // but don't update lastId if an earlier started call is still active
-                if (singleCall.type > 3) {
+                if (singleCall.type == 9 || singleCall.type == 11) {
                     blocker = true;
                 }
 
                 if (!blocker && singleCall.id > systemData.native.callLists.lastId) {
                     systemData.native.callLists.lastId = singleCall.id;
-                    adapter.log.debug('Last.id updated to ' + singleCall.id);
                 }
             });
         } else {


### PR DESCRIPTION
Anpassung beim Calllist-Handling, weil blockierte Calls (Fritzbox: Rufsperre) den call.type 10 dauerhaft behalten und somit hier dauerhaft als "aktiv" gewertet werden. Dadurch wird die last.id nicht aktualisiert (weil ja noch ein  Call vermeintlich aktiv ist) und somit werden unnötigerweise immer alle Calls seit dem letzten blockierten Call von der Fritzbox abgefragt.