### PR TITLE
callmonitor: downgrade expected disconnects to info level

### DIFF
--- a/lib/callmonitor.js
+++ b/lib/callmonitor.js
@@ -224,8 +224,14 @@ function CallMonitor(adapter, devices, phonebook) {
             host: adapter.config.ip || adapter.config.iporhost,
             port: 1012
         })
-            .on('error', error =>
-                adapter.log.error('Cannot start ' + CALLMONITOR_NAME + ': ' + error));
+            .on('error', (err) => {
+                const isExpectedDrop = err && (err.code === 'ETIMEDOUT' || err.code === 'ECONNRESET' || err.code === 'EPIPE');
+                if (isExpectedDrop) {
+                  adapter.log.info(`${CALLMONITOR_NAME} connection dropped (${err.code}); will reconnect.`);
+                } else {
+                  adapter.log.error(`Cannot start ${CALLMONITOR_NAME}: ${err?.stack || err}`);
+                }
+            });
     }
 
     this.close = function () {


### PR DESCRIPTION
### Problem
With FRITZ!OS 8.x (e.g. 8.25 on FRITZ!Box 7590 AX) the callmonitor TCP
connection (port 1012) is closed by the FRITZ!Box after longer idle periods.

The adapter reconnects successfully and call events continue to work,
but the reconnect is logged as an error:
`Cannot start callmonitor: read ETIMEDOUT`

### Change
- Treat ETIMEDOUT, ECONNRESET and EPIPE as expected socket disconnects
- Log these cases as `info` instead of `error`
- Keep all other errors unchanged

### Result
- No functional change
- Automatic reconnect still works
- Avoids repeated error log spam for a known, expected behavior

### Tested
- ioBroker native on macOS (Apple Silicon)
- FRITZ!Box 7590 AX, FRITZ!OS 8.25
- Callmonitor reconnects and call events still work as expected